### PR TITLE
add minimum_comment_severity option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,11 +11,14 @@ clean:
 format: 
 	gofmt -w ./...
 
+test:
+	go test ./...
+
 cov:
-	-go test -coverpkg=./... -coverprofile=coverage.txt -covermode count ./...
-	-gocover-cobertura < coverage.txt > coverage.xml
-	-go tool cover -html=coverage.txt -o coverage.html
-	-go tool cover -func=coverage.txt
+	go test -coverpkg=./... -coverprofile=coverage.txt -covermode count ./...
+	gocover-cobertura < coverage.txt > coverage.xml
+	go tool cover -html=coverage.txt -o coverage.html
+	go tool cover -func=coverage.txt
 
 lint:
 	docker run --rm -v $(shell pwd):/app -w /app golangci/golangci-lint:v1.44.2 golangci-lint run --enable gofmt,stylecheck,gosec ./...

--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,10 @@ test:
 	go test ./...
 
 cov:
-	go test -coverpkg=./... -coverprofile=coverage.txt -covermode count ./...
-	gocover-cobertura < coverage.txt > coverage.xml
-	go tool cover -html=coverage.txt -o coverage.html
-	go tool cover -func=coverage.txt
+	-go test -coverpkg=./... -coverprofile=coverage.txt -covermode count ./...
+	-gocover-cobertura < coverage.txt > coverage.xml
+	-go tool cover -html=coverage.txt -o coverage.html
+	-go tool cover -func=coverage.txt
 
 lint:
 	docker run --rm -v $(shell pwd):/app -w /app golangci/golangci-lint:v1.44.2 golangci-lint run --enable gofmt,stylecheck,gosec ./...

--- a/data/nullify.yaml
+++ b/data/nullify.yaml
@@ -1,1 +1,2 @@
+minimum_comment_severity: medium
 ignore_dirs: ["data"]

--- a/go.mod
+++ b/go.mod
@@ -10,4 +10,5 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/exp v0.0.0-20230321023759-10a507213a29
 )

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+golang.org/x/exp v0.0.0-20230321023759-10a507213a29 h1:ooxPy7fPvB4kwsA2h+iBNHkAbp/4JxTSwCmvdjEYmug=
+golang.org/x/exp v0.0.0-20230321023759-10a507213a29/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/models/config.go
+++ b/pkg/models/config.go
@@ -1,5 +1,6 @@
 package models
 
 type Configuration struct {
-	IgnoreDirs []string `yaml:"ignore_dirs"`
+	MinimumCommentSeverity string   `yaml:"minimum_comment_severity"`
+	IgnoreDirs             []string `yaml:"ignore_dirs"`
 }

--- a/pkg/models/severity.go
+++ b/pkg/models/severity.go
@@ -1,0 +1,8 @@
+package models
+
+const (
+	SeverityCritical = "CRITICAL"
+	SeverityHigh     = "HIGH"
+	SeverityMedium   = "MEDIUM"
+	SeverityLow      = "LOW"
+)

--- a/pkg/parser/parse_test.go
+++ b/pkg/parser/parse_test.go
@@ -7,10 +7,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const configStr string = `
+minimum_comment_severity: medium
+ignore_dirs: ["data"]
+`
+
 func TestParseConfiguration(t *testing.T) {
-	configStr := "ignore_dirs: [\"data\"]"
 	config, err := ParseConfiguration([]byte(configStr))
 	require.NoError(t, err)
+	assert.Equal(t, "medium", config.MinimumCommentSeverity)
 	assert.Equal(t, 1, len(config.IgnoreDirs))
 	assert.Equal(t, "data", config.IgnoreDirs[0])
 }

--- a/pkg/parser/validate.go
+++ b/pkg/parser/validate.go
@@ -1,0 +1,18 @@
+package parser
+
+import (
+	"github.com/nullify-platform/config-file-parser/pkg/models"
+	"golang.org/x/exp/slices"
+)
+
+var validSeveritites = []string{
+	"",
+	models.SeverityLow,
+	models.SeverityMedium,
+	models.SeverityHigh,
+	models.SeverityCritical,
+}
+
+func ValidateConfig(config *models.Configuration) bool {
+	return slices.Contains(validSeveritites, config.MinimumCommentSeverity)
+}


### PR DESCRIPTION
## Description

Add minimum_comment_severity option which users can set to change the vulnerability severity which triggers nullify to leave a pull request comment.

## Linked issues

- https://github.com/Nullify-Platform/The-Force/issues/576

## Checklist

- [x] I have added one of the `patch`, `minor`, `major` or `no-release` labels
- [x] I have performed a self-review of my own code
- [x] I have checked for redundant or commented out code
- [x] I have commented my code where I can't make it self-documenting
- [x] I have made corresponding changes to the documentation
- [x] I have added any appropriate tests
