### PR TITLE
add default values

### DIFF
--- a/pkg/models/severity.go
+++ b/pkg/models/severity.go
@@ -5,4 +5,5 @@ const (
 	SeverityHigh     = "HIGH"
 	SeverityMedium   = "MEDIUM"
 	SeverityLow      = "LOW"
+	SeverityUnknown  = "UNKNOWN"
 )

--- a/pkg/parser/defaults.go
+++ b/pkg/parser/defaults.go
@@ -1,0 +1,10 @@
+package parser
+
+import "github.com/nullify-platform/config-file-parser/pkg/models"
+
+func GetDefaultConfig() *models.Configuration {
+	return &models.Configuration{
+		MinimumCommentSeverity: models.SeverityMedium,
+		IgnoreDirs:             []string{},
+	}
+}

--- a/pkg/parser/defaults.go
+++ b/pkg/parser/defaults.go
@@ -2,9 +2,11 @@ package parser
 
 import "github.com/nullify-platform/config-file-parser/pkg/models"
 
-func GetDefaultConfig() *models.Configuration {
+const DefaultMinimumCommentSeverity = models.SeverityMedium
+
+func NewDefaultConfig() *models.Configuration {
 	return &models.Configuration{
-		MinimumCommentSeverity: models.SeverityMedium,
+		MinimumCommentSeverity: DefaultMinimumCommentSeverity,
 		IgnoreDirs:             []string{},
 	}
 }

--- a/pkg/parser/parse.go
+++ b/pkg/parser/parse.go
@@ -8,7 +8,7 @@ import (
 )
 
 func ParseConfiguration(data []byte) (*models.Configuration, error) {
-	config := GetDefaultConfig()
+	config := NewDefaultConfig()
 	err := yaml.Unmarshal([]byte(data), config)
 	if err != nil {
 		return nil, err
@@ -19,4 +19,7 @@ func ParseConfiguration(data []byte) (*models.Configuration, error) {
 
 func sanitizeConfig(config *models.Configuration) {
 	config.MinimumCommentSeverity = strings.ToUpper(config.MinimumCommentSeverity)
+	if config.MinimumCommentSeverity == "" {
+		config.MinimumCommentSeverity = DefaultMinimumCommentSeverity
+	}
 }

--- a/pkg/parser/parse.go
+++ b/pkg/parser/parse.go
@@ -1,15 +1,22 @@
 package parser
 
 import (
+	"strings"
+
 	"github.com/nullify-platform/config-file-parser/pkg/models"
 	"gopkg.in/yaml.v3"
 )
 
 func ParseConfiguration(data []byte) (*models.Configuration, error) {
-	config := models.Configuration{}
-	err := yaml.Unmarshal([]byte(data), &config)
+	config := GetDefaultConfig()
+	err := yaml.Unmarshal([]byte(data), config)
 	if err != nil {
 		return nil, err
 	}
-	return &config, nil
+	sanitizeConfig(config)
+	return config, nil
+}
+
+func sanitizeConfig(config *models.Configuration) {
+	config.MinimumCommentSeverity = strings.ToUpper(config.MinimumCommentSeverity)
 }

--- a/pkg/parser/parse_test.go
+++ b/pkg/parser/parse_test.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"testing"
 
+	"github.com/nullify-platform/config-file-parser/pkg/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -12,10 +13,37 @@ minimum_comment_severity: medium
 ignore_dirs: ["data"]
 `
 
-func TestParseConfiguration(t *testing.T) {
-	config, err := ParseConfiguration([]byte(configStr))
-	require.NoError(t, err)
-	assert.Equal(t, "medium", config.MinimumCommentSeverity)
-	assert.Equal(t, 1, len(config.IgnoreDirs))
-	assert.Equal(t, "data", config.IgnoreDirs[0])
+func TestValidateMinimumCommentSeverity(t *testing.T) {
+	for _, scenario := range []struct {
+		name     string
+		data     string
+		expected *models.Configuration
+	}{
+		{
+			name: "default values",
+			data: "",
+			expected: &models.Configuration{
+				MinimumCommentSeverity: models.SeverityMedium,
+				IgnoreDirs:             []string{},
+			},
+		},
+		{
+			name: "",
+			data: configStr,
+			expected: &models.Configuration{
+				MinimumCommentSeverity: models.SeverityMedium,
+				IgnoreDirs:             []string{"data"},
+			},
+		},
+	} {
+		t.Run(scenario.name, func(t *testing.T) {
+			config, err := ParseConfiguration([]byte(scenario.data))
+			require.NoError(t, err)
+			assert.Equal(t, scenario.expected.MinimumCommentSeverity, config.MinimumCommentSeverity)
+			require.Equal(t, len(scenario.expected.IgnoreDirs), len(config.IgnoreDirs))
+			for i, v := range config.IgnoreDirs {
+				assert.Equal(t, v, scenario.expected.IgnoreDirs[i])
+			}
+		})
+	}
 }

--- a/pkg/parser/parse_test.go
+++ b/pkg/parser/parse_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 const configStr string = `
-minimum_comment_severity: medium
+minimum_comment_severity: high
 ignore_dirs: ["data"]
 `
 
@@ -28,11 +28,19 @@ func TestValidateMinimumCommentSeverity(t *testing.T) {
 			},
 		},
 		{
-			name: "",
+			name: "user provided values",
 			data: configStr,
 			expected: &models.Configuration{
-				MinimumCommentSeverity: models.SeverityMedium,
+				MinimumCommentSeverity: models.SeverityHigh,
 				IgnoreDirs:             []string{"data"},
+			},
+		},
+		{
+			name: "user provided empty minimum_comment_severity",
+			data: "minimum_comment_severity: ''",
+			expected: &models.Configuration{
+				MinimumCommentSeverity: models.SeverityMedium,
+				IgnoreDirs:             []string{},
 			},
 		},
 	} {

--- a/pkg/parser/parse_test.go
+++ b/pkg/parser/parse_test.go
@@ -13,7 +13,7 @@ minimum_comment_severity: high
 ignore_dirs: ["data"]
 `
 
-func TestValidateMinimumCommentSeverity(t *testing.T) {
+func TestParseConfiguration(t *testing.T) {
 	for _, scenario := range []struct {
 		name     string
 		data     string
@@ -24,7 +24,7 @@ func TestValidateMinimumCommentSeverity(t *testing.T) {
 			data: "",
 			expected: &models.Configuration{
 				MinimumCommentSeverity: models.SeverityMedium,
-				IgnoreDirs:             []string{},
+				IgnoreDirs:             nil,
 			},
 		},
 		{
@@ -40,7 +40,15 @@ func TestValidateMinimumCommentSeverity(t *testing.T) {
 			data: "minimum_comment_severity: ''",
 			expected: &models.Configuration{
 				MinimumCommentSeverity: models.SeverityMedium,
-				IgnoreDirs:             []string{},
+				IgnoreDirs:             nil,
+			},
+		},
+		{
+			name: "user provided low minimum_comment_severity",
+			data: "minimum_comment_severity: 'low'",
+			expected: &models.Configuration{
+				MinimumCommentSeverity: models.SeverityLow,
+				IgnoreDirs:             nil,
 			},
 		},
 	} {

--- a/pkg/parser/parse_test.go
+++ b/pkg/parser/parse_test.go
@@ -44,8 +44,8 @@ func TestParseConfiguration(t *testing.T) {
 			},
 		},
 		{
-			name: "user provided low minimum_comment_severity",
-			data: "minimum_comment_severity: 'low'",
+			name: "user provided LOW minimum_comment_severity",
+			data: "minimum_comment_severity: 'LOW'",
 			expected: &models.Configuration{
 				MinimumCommentSeverity: models.SeverityLow,
 				IgnoreDirs:             nil,

--- a/pkg/validator/severity.go
+++ b/pkg/validator/severity.go
@@ -1,8 +1,6 @@
 package validator
 
 import (
-	"strings"
-
 	"github.com/nullify-platform/config-file-parser/pkg/models"
 	"golang.org/x/exp/slices"
 )
@@ -23,5 +21,5 @@ var validSeveritites = []string{
 //   - HIGH / high
 //   - CRITICAL / critical
 func ValidateMinimumCommentSeverity(config *models.Configuration) bool {
-	return slices.Contains(validSeveritites, strings.ToUpper(config.MinimumCommentSeverity))
+	return slices.Contains(validSeveritites, config.MinimumCommentSeverity)
 }

--- a/pkg/validator/severity.go
+++ b/pkg/validator/severity.go
@@ -6,7 +6,6 @@ import (
 )
 
 var validSeveritites = []string{
-	"",
 	models.SeverityLow,
 	models.SeverityMedium,
 	models.SeverityHigh,

--- a/pkg/validator/severity_test.go
+++ b/pkg/validator/severity_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/nullify-platform/config-file-parser/pkg/models"
+	"github.com/nullify-platform/config-file-parser/pkg/parser"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -14,30 +15,42 @@ func TestValidateMinimumCommentSeverity(t *testing.T) {
 		expected bool
 	}{
 		{
+			name:     "empty configuration",
 			config:   &models.Configuration{},
+			expected: false,
+		},
+		{
+			name:     "default configuration",
+			config:   parser.NewDefaultConfig(),
 			expected: true,
 		},
 		{
+			name:     "empty MinimumCommentSeverity",
 			config:   &models.Configuration{MinimumCommentSeverity: ""},
-			expected: true,
+			expected: false,
 		},
 		{
+			name:     "SeverityLow",
 			config:   &models.Configuration{MinimumCommentSeverity: models.SeverityLow},
 			expected: true,
 		},
 		{
+			name:     "SeverityMedium",
 			config:   &models.Configuration{MinimumCommentSeverity: models.SeverityMedium},
 			expected: true,
 		},
 		{
+			name:     "SeverityHigh",
 			config:   &models.Configuration{MinimumCommentSeverity: models.SeverityHigh},
 			expected: true,
 		},
 		{
+			name:     "SeverityCritical",
 			config:   &models.Configuration{MinimumCommentSeverity: models.SeverityCritical},
 			expected: true,
 		},
 		{
+			name:     "unexpected severity",
 			config:   &models.Configuration{MinimumCommentSeverity: "invalid-severity"},
 			expected: false,
 		},

--- a/pkg/validator/severity_test.go
+++ b/pkg/validator/severity_test.go
@@ -1,7 +1,6 @@
 package validator
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/nullify-platform/config-file-parser/pkg/models"
@@ -27,15 +26,7 @@ func TestValidateMinimumCommentSeverity(t *testing.T) {
 			expected: true,
 		},
 		{
-			config:   &models.Configuration{MinimumCommentSeverity: strings.ToLower(models.SeverityLow)},
-			expected: true,
-		},
-		{
 			config:   &models.Configuration{MinimumCommentSeverity: models.SeverityMedium},
-			expected: true,
-		},
-		{
-			config:   &models.Configuration{MinimumCommentSeverity: strings.ToLower(models.SeverityMedium)},
 			expected: true,
 		},
 		{
@@ -43,15 +34,7 @@ func TestValidateMinimumCommentSeverity(t *testing.T) {
 			expected: true,
 		},
 		{
-			config:   &models.Configuration{MinimumCommentSeverity: strings.ToLower(models.SeverityHigh)},
-			expected: true,
-		},
-		{
 			config:   &models.Configuration{MinimumCommentSeverity: models.SeverityCritical},
-			expected: true,
-		},
-		{
-			config:   &models.Configuration{MinimumCommentSeverity: strings.ToLower(models.SeverityCritical)},
 			expected: true,
 		},
 		{


### PR DESCRIPTION
## Description

Created a public function to return the default values if the user doesn't set them.
The ParseConfiguration function also uses this to set default values in parsed config files.

## Linked issues

- https://github.com/Nullify-Platform/The-Force/issues/576

## Checklist

- [x] I have added one of the `patch`, `minor`, `major` or `no-release` labels
- [x] I have performed a self-review of my own code
- [x] I have checked for redundant or commented out code
- [x] I have commented my code where I can't make it self-documenting
- [ ] I have made corresponding changes to the documentation
- [x] I have added any appropriate tests
