### PR TITLE
update minimum_comment_severity to severity_threshold

### DIFF
--- a/data/nullify.yaml
+++ b/data/nullify.yaml
@@ -1,3 +1,3 @@
-minimum_comment_severity: medium
+severity_threshold: medium
 ignore_dirs: ["data"]
 email_notifications: ["notifications@nullify.cloud", "noreply@nullify.cloud"]

--- a/pkg/models/config.go
+++ b/pkg/models/config.go
@@ -1,8 +1,8 @@
 package models
 
 type Configuration struct {
-	MinimumCommentSeverity string   `yaml:"minimum_comment_severity"`
-	IgnoreDirs             []string `yaml:"ignore_dirs"`
-	EmailNotifications     []string `yaml:"email_notifications"`
-	SecretsWhitelist       []string `yaml:"secrets_whitelist"`
+	SeverityThreshold  string   `yaml:"severity_threshold"`
+	IgnoreDirs         []string `yaml:"ignore_dirs"`
+	EmailNotifications []string `yaml:"email_notifications"`
+	SecretsWhitelist   []string `yaml:"secrets_whitelist"`
 }

--- a/pkg/parser/defaults.go
+++ b/pkg/parser/defaults.go
@@ -2,11 +2,11 @@ package parser
 
 import "github.com/nullify-platform/config-file-parser/pkg/models"
 
-const DefaultMinimumCommentSeverity = models.SeverityHigh
+const DefaultSeverityThreshold = models.SeverityMedium
 
 func NewDefaultConfig() *models.Configuration {
 	return &models.Configuration{
-		MinimumCommentSeverity: DefaultMinimumCommentSeverity,
-		IgnoreDirs:             []string{},
+		SeverityThreshold: DefaultSeverityThreshold,
+		IgnoreDirs:        []string{},
 	}
 }

--- a/pkg/parser/parse.go
+++ b/pkg/parser/parse.go
@@ -18,8 +18,8 @@ func ParseConfiguration(data []byte) (*models.Configuration, error) {
 }
 
 func sanitizeConfig(config *models.Configuration) {
-	config.MinimumCommentSeverity = strings.ToUpper(config.MinimumCommentSeverity)
-	if config.MinimumCommentSeverity == "" {
-		config.MinimumCommentSeverity = DefaultMinimumCommentSeverity
+	config.SeverityThreshold = strings.ToUpper(config.SeverityThreshold)
+	if config.SeverityThreshold == "" {
+		config.SeverityThreshold = DefaultSeverityThreshold
 	}
 }

--- a/pkg/parser/parse_test.go
+++ b/pkg/parser/parse_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 const configStr string = `
-minimum_comment_severity: high
+severity_threshold: high
 ignore_dirs: ["data"]
 secrets_whitelist: ["secretPassword",	 "superSecretPassword"]
 `
@@ -24,61 +24,61 @@ func TestParseConfiguration(t *testing.T) {
 			name: "default values",
 			data: "",
 			expected: &models.Configuration{
-				MinimumCommentSeverity: models.SeverityMedium,
-				IgnoreDirs:             nil,
-				SecretsWhitelist:       nil,
+				SeverityThreshold: models.SeverityMedium,
+				IgnoreDirs:        nil,
+				SecretsWhitelist:  nil,
 			},
 		},
 		{
 			name: "user provided values",
 			data: configStr,
 			expected: &models.Configuration{
-				MinimumCommentSeverity: models.SeverityHigh,
-				IgnoreDirs:             []string{"data"},
-				SecretsWhitelist:       []string{"secretPassword", "superSecretPassword"},
+				SeverityThreshold: models.SeverityHigh,
+				IgnoreDirs:        []string{"data"},
+				SecretsWhitelist:  []string{"secretPassword", "superSecretPassword"},
 			},
 		},
 		{
-			name: "user provided empty minimum_comment_severity",
-			data: "minimum_comment_severity: ''",
+			name: "user provided empty severity_threshold",
+			data: "severity_threshold: ''",
 			expected: &models.Configuration{
-				MinimumCommentSeverity: models.SeverityMedium,
-				IgnoreDirs:             nil,
-				SecretsWhitelist:       nil,
+				SeverityThreshold: models.SeverityMedium,
+				IgnoreDirs:        nil,
+				SecretsWhitelist:  nil,
 			},
 		},
 		{
-			name: "user provided LOW minimum_comment_severity",
-			data: "minimum_comment_severity: 'LOW'",
+			name: "user provided LOW severity_threshold",
+			data: "severity_threshold: 'LOW'",
 			expected: &models.Configuration{
-				MinimumCommentSeverity: models.SeverityLow,
-				IgnoreDirs:             nil,
-				SecretsWhitelist:       nil,
+				SeverityThreshold: models.SeverityLow,
+				IgnoreDirs:        nil,
+				SecretsWhitelist:  nil,
 			},
 		},
 		{
 			name: "user provided a single secret",
 			data: `secrets_whitelist: ["password"]`,
 			expected: &models.Configuration{
-				MinimumCommentSeverity: models.SeverityMedium,
-				IgnoreDirs:             nil,
-				SecretsWhitelist:       []string{"password"},
+				SeverityThreshold: models.SeverityMedium,
+				IgnoreDirs:        nil,
+				SecretsWhitelist:  []string{"password"},
 			},
 		},
 		{
 			name: "user provided empty secret whitelist",
 			data: `secrets_whitelist: `,
 			expected: &models.Configuration{
-				MinimumCommentSeverity: models.SeverityMedium,
-				IgnoreDirs:             nil,
-				SecretsWhitelist:       nil,
+				SeverityThreshold: models.SeverityMedium,
+				IgnoreDirs:        nil,
+				SecretsWhitelist:  nil,
 			},
 		},
 	} {
 		t.Run(scenario.name, func(t *testing.T) {
 			config, err := ParseConfiguration([]byte(scenario.data))
 			require.NoError(t, err)
-			assert.Equal(t, scenario.expected.MinimumCommentSeverity, config.MinimumCommentSeverity)
+			assert.Equal(t, scenario.expected.SeverityThreshold, config.SeverityThreshold)
 			require.Equal(t, len(scenario.expected.IgnoreDirs), len(config.IgnoreDirs))
 			for i, v := range config.IgnoreDirs {
 				assert.Equal(t, v, scenario.expected.IgnoreDirs[i])

--- a/pkg/validator/emails_test.go
+++ b/pkg/validator/emails_test.go
@@ -54,46 +54,46 @@ func TestValidEmails(t *testing.T) {
 }
 
 const validEmail string = `
-minimum_comment_severity: medium
+severity_threshold: medium
 ignore_dirs: ["data"]	
 email_notifications: ["hello@gmail.com"]
 `
 
 const emptyEmail string = `
-minimum_comment_severity: medium
+severity_threshold: medium
 ignore_dirs: ["data"]	
 email_notifications:
 `
 
 const noEmailConfig string = `
-minimum_comment_severity: medium
+severity_threshold: medium
 ignore_dirs: ["data"]	
 `
 const emailWithEmptyArray string = `
-minimum_comment_severity: medium
+severity_threshold: medium
 ignore_dirs: ["data"]	
 email_notifications: [""]
 `
 
 const twoValidEmails string = `
-minimum_comment_severity: medium
+severity_threshold: medium
 ignore_dirs: ["data"]	
 email_notifications: ["john@nullify.cloud", "lisa@gmail.com"]
 `
 const validAndInvalid string = `
-minimum_comment_severity: medium
+severity_threshold: medium
 ignore_dirs: ["data"]	
 email_notifications: ["john()@nullify.cloud", "lisa@gmail.com"]
 `
 
 const missingCommaIncorrectQuotes string = `
-minimum_comment_severity: medium
+severity_threshold: medium
 ignore_dirs: ["data"]	
 email_notifications: ["hello@gmail.com john@nullify.cloud"]
 `
 
 const missingComma string = `
-minimum_comment_severity: medium
+severity_threshold: medium
 ignore_dirs: ["data"]	
 email_notifications: ["hello@gmail.com" "john@nullify.cloud"]
 `

--- a/pkg/validator/severity.go
+++ b/pkg/validator/severity.go
@@ -12,13 +12,13 @@ var validSeveritites = []string{
 	models.SeverityCritical,
 }
 
-// ValidateMinimumCommentSeverity returns true if the minimum_comment_severity
+// ValidateSeverityThreshold returns true if the severity_threshold
 // option is one of the valid values:
 //   - ""
 //   - LOW / low
 //   - MEDIUM / medium
 //   - HIGH / high
 //   - CRITICAL / critical
-func ValidateMinimumCommentSeverity(config *models.Configuration) bool {
-	return slices.Contains(validSeveritites, config.MinimumCommentSeverity)
+func ValidateSeverityThreshold(config *models.Configuration) bool {
+	return slices.Contains(validSeveritites, config.SeverityThreshold)
 }

--- a/pkg/validator/severity_test.go
+++ b/pkg/validator/severity_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestValidateMinimumCommentSeverity(t *testing.T) {
+func TestValidateSeverityThreshold(t *testing.T) {
 	for _, scenario := range []struct {
 		name     string
 		config   *models.Configuration
@@ -25,38 +25,38 @@ func TestValidateMinimumCommentSeverity(t *testing.T) {
 			expected: true,
 		},
 		{
-			name:     "empty MinimumCommentSeverity",
-			config:   &models.Configuration{MinimumCommentSeverity: ""},
+			name:     "empty SeverityThreshold",
+			config:   &models.Configuration{SeverityThreshold: ""},
 			expected: false,
 		},
 		{
 			name:     "SeverityLow",
-			config:   &models.Configuration{MinimumCommentSeverity: models.SeverityLow},
+			config:   &models.Configuration{SeverityThreshold: models.SeverityLow},
 			expected: true,
 		},
 		{
 			name:     "SeverityMedium",
-			config:   &models.Configuration{MinimumCommentSeverity: models.SeverityMedium},
+			config:   &models.Configuration{SeverityThreshold: models.SeverityMedium},
 			expected: true,
 		},
 		{
 			name:     "SeverityHigh",
-			config:   &models.Configuration{MinimumCommentSeverity: models.SeverityHigh},
+			config:   &models.Configuration{SeverityThreshold: models.SeverityHigh},
 			expected: true,
 		},
 		{
 			name:     "SeverityCritical",
-			config:   &models.Configuration{MinimumCommentSeverity: models.SeverityCritical},
+			config:   &models.Configuration{SeverityThreshold: models.SeverityCritical},
 			expected: true,
 		},
 		{
 			name:     "unexpected severity",
-			config:   &models.Configuration{MinimumCommentSeverity: "invalid-severity"},
+			config:   &models.Configuration{SeverityThreshold: "invalid-severity"},
 			expected: false,
 		},
 	} {
 		t.Run(scenario.name, func(t *testing.T) {
-			isValid := ValidateMinimumCommentSeverity(scenario.config)
+			isValid := ValidateSeverityThreshold(scenario.config)
 			assert.Equal(t, scenario.expected, isValid)
 		})
 	}

--- a/pkg/validator/validate.go
+++ b/pkg/validator/validate.go
@@ -6,5 +6,5 @@ import (
 
 // ValidateConfig return true if provided configuration is valid
 func ValidateConfig(config *models.Configuration) bool {
-	return ValidateMinimumCommentSeverity(config) && ValidateEmail(config)
+	return ValidateSeverityThreshold(config) && ValidateEmail(config)
 }


### PR DESCRIPTION
## Description

Changes minimum_comment_severity to severity_threshold so that the config file option is inclusive of issue dashboards.

## Linked Issues & PRs

- https://github.com/Nullify-Platform/Rebel-Alliance/issues/127

[GitHub Issue Linking Docs](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)

## Checklist

- [ ] I have added one of the `patch`, `minor`, `major` or `no-release` labels
- [ ] I have linked an issue from this repository using the **Development** option
- [ ] I have performed a self-review of my own code
- [ ] I have checked for redundant or commented out code
- [ ] I have commented my code where I can't make it self-documenting
- [ ] I have made corresponding changes to the documentation
- [ ] I have added any appropriate tests
