### PR TITLE
use allowlist instead of whitelist

### DIFF
--- a/pkg/models/config.go
+++ b/pkg/models/config.go
@@ -5,5 +5,7 @@ type Configuration struct {
 	IgnoreDirs         []string `yaml:"ignore_dirs"`
 	IgnorePaths        []string `yaml:"ignore_paths"`
 	EmailNotifications []string `yaml:"email_notifications"`
-	SecretsWhitelist   []string `yaml:"secrets_whitelist"`
+	// TODO deprecate
+	SecretsWhitelist []string `yaml:"secrets_whitelist"`
+	SecretsAllowlist []string `yaml:"secrets_allowlist"`
 }

--- a/pkg/parser/parse_test.go
+++ b/pkg/parser/parse_test.go
@@ -28,6 +28,7 @@ func TestParseConfiguration(t *testing.T) {
 				IgnoreDirs:        nil,
 				IgnorePaths:       nil,
 				SecretsWhitelist:  nil,
+				SecretsAllowlist:  nil,
 			},
 		},
 		{
@@ -38,6 +39,7 @@ func TestParseConfiguration(t *testing.T) {
 				IgnoreDirs:        []string{"data"},
 				IgnorePaths:       []string{"*d"},
 				SecretsWhitelist:  []string{"secretPassword", "superSecretPassword"},
+				SecretsAllowlist:  []string{"secretPassword", "superSecretPassword"},
 			},
 		},
 		{
@@ -48,6 +50,7 @@ func TestParseConfiguration(t *testing.T) {
 				IgnoreDirs:        nil,
 				IgnorePaths:       nil,
 				SecretsWhitelist:  nil,
+				SecretsAllowlist:  nil,
 			},
 		},
 		{
@@ -58,6 +61,7 @@ func TestParseConfiguration(t *testing.T) {
 				IgnoreDirs:        nil,
 				IgnorePaths:       nil,
 				SecretsWhitelist:  nil,
+				SecretsAllowlist:  nil,
 			},
 		},
 		{
@@ -68,6 +72,7 @@ func TestParseConfiguration(t *testing.T) {
 				IgnoreDirs:        nil,
 				IgnorePaths:       nil,
 				SecretsWhitelist:  []string{"password"},
+				SecretsAllowlist:  []string{"password"},
 			},
 		},
 		{
@@ -76,8 +81,9 @@ func TestParseConfiguration(t *testing.T) {
 			expected: &models.Configuration{
 				SeverityThreshold: models.SeverityMedium,
 				IgnoreDirs:        nil,
-				SecretsWhitelist:  nil,
 				IgnorePaths:       nil,
+				SecretsWhitelist:  nil,
+				SecretsAllowlist:  nil,
 			},
 		},
 		{
@@ -88,6 +94,7 @@ func TestParseConfiguration(t *testing.T) {
 				IgnoreDirs:        nil,
 				IgnorePaths:       nil,
 				SecretsWhitelist:  nil,
+				SecretsAllowlist:  nil,
 			},
 		},
 		{
@@ -98,6 +105,7 @@ func TestParseConfiguration(t *testing.T) {
 				IgnoreDirs:        nil,
 				IgnorePaths:       []string{"*d"},
 				SecretsWhitelist:  nil,
+				SecretsAllowlist:  nil,
 			},
 		},
 	} {

--- a/pkg/validator/whitelist_secrets.go
+++ b/pkg/validator/whitelist_secrets.go
@@ -10,5 +10,9 @@ func ValidateSecrets(config *models.Configuration) bool {
 		return true
 	}
 
+	if config.SecretsAllowlist == nil {
+		return true
+	}
+
 	return true
 }


### PR DESCRIPTION
## Description

Allowlist is a better term to use.
We should remove whitelist from the docs and deprecate it when everyone stops using it.

## Checklist

- [ ] I have added one of the `patch`, `minor`, `major` or `no-release` labels
- [ ] I have linked an issue from this repository using the **Development** option
- [ ] I have performed a self-review of my own code
- [ ] I have checked for redundant or commented out code
- [ ] I have commented my code where I can't make it self-documenting
- [ ] I have made corresponding changes to the documentation
- [ ] I have added any appropriate tests
