### PR TITLE
add ability to ignore cwe's and rule ids for code/sast

### DIFF
--- a/data/nullify.yaml
+++ b/data/nullify.yaml
@@ -36,6 +36,14 @@ scheduled_notifications:
           - monitoring@nullify.ai
       slack:
         channel: "123456"
+code:
+  ignore:
+    - cwes: [ 589 ] # Potential HTTP request made with variable url
+      reason: HTTP requests with variables in tests don't matter
+      paths: "**/tests/*"
+    - rule_ids: [ python-sql-injection ]
+      reason: This code won't be going live until next year but we should fix it before then
+      expiry: "2021-12-31"
 dependencies:
   ignore:
     - cve: CVE-2021-1234

--- a/pkg/models/code.go
+++ b/pkg/models/code.go
@@ -1,0 +1,14 @@
+package models
+
+type Code struct {
+	Ignore []CodeIgnore `yaml:"ignore,omitempty"`
+}
+
+type CodeIgnore struct {
+	CWEs    []int    `yaml:"cwes,omitempty"`
+	RuleIDs []string `yaml:"rule_ids,omitempty"`
+	Reason  string   `yaml:"reason,omitempty"`
+	Dirs    []string `yaml:"dirs,omitempty"`
+	Paths   []string `yaml:"paths,omitempty"`
+	Expiry  string   `yaml:"expiry,omitempty"`
+}

--- a/pkg/models/dependencies.go
+++ b/pkg/models/dependencies.go
@@ -5,7 +5,9 @@ type Dependencies struct {
 }
 
 type DependenciesIgnore struct {
-	CVE    string `yaml:"cve,omitempty"`
-	Reason string `yaml:"reason,omitempty"`
-	Expiry string `yaml:"expiry,omitempty"`
+	CVE    string   `yaml:"cve,omitempty"`
+	Reason string   `yaml:"reason,omitempty"`
+	Expiry string   `yaml:"expiry,omitempty"`
+	Dirs   []string `yaml:"dirs,omitempty"`
+	Paths  []string `yaml:"paths,omitempty"`
 }

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -4,9 +4,10 @@ type Configuration struct {
 	SeverityThreshold      string                           `yaml:"severity_threshold,omitempty"`
 	IgnoreDirs             []string                         `yaml:"ignore_dirs,omitempty"`
 	IgnorePaths            []string                         `yaml:"ignore_paths,omitempty"`
-	SecretsWhitelist       []string                         `yaml:"secrets_whitelist,omitempty"` // TODO deprecate
+	Code                   Code                             `yaml:"code,omitempty"`
 	Dependencies           Dependencies                     `yaml:"dependencies,omitempty"`
 	Secrets                Secrets                          `yaml:"secrets,omitempty"`
+	SecretsWhitelist       []string                         `yaml:"secrets_whitelist,omitempty"` // TODO deprecate
 	Notifications          map[string]Notification          `yaml:"notifications,omitempty"`
 	ScheduledNotifications map[string]ScheduledNotification `yaml:"scheduled_notifications,omitempty"`
 }

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -83,6 +83,20 @@ func TestIntegration(t *testing.T) {
 				},
 			},
 		},
+		Code: models.Code{
+			Ignore: []models.CodeIgnore{
+				{
+					CWEs:   []int{589},
+					Reason: "HTTP requests with variables in tests don't matter",
+					Paths:  []string{"**/tests/*"},
+				},
+				{
+					RuleIDs: []string{"python-sql-injection"},
+					Reason:  "This code won't be going live until next year but we should fix it before then",
+					Expiry:  "2021-12-31",
+				},
+			},
+		},
 		Dependencies: models.Dependencies{
 			Ignore: []models.DependenciesIgnore{
 				{

--- a/tests/nullify.yaml
+++ b/tests/nullify.yaml
@@ -35,6 +35,14 @@ scheduled_notifications:
         channels: [ "123456" ]
       email:
         addresses: [ notifications@nullify.ai, noreply@nullify.ai ]
+code:
+  ignore:
+    - cwes: [ 589 ] # Potential HTTP request made with variable url
+      reason: HTTP requests with variables in tests don't matter
+      paths: [ "**/tests/*" ]
+    - rule_ids: [ python-sql-injection ]
+      reason: This code won't be going live until next year but we should fix it before then
+      expiry: "2021-12-31"
 dependencies:
   ignore:
     - cve: CVE-2021-1234


### PR DESCRIPTION
## Description

Ignore CWEs and/or rule IDs with a reason and only applying to matching directories or path patterns.

## Checklist

- [ ] I have added one of the `patch`, `minor`, `major` or `no-release` labels
- [ ] I have linked an issue from this repository using the **Development** option
- [ ] I have performed a self-review of my own code
- [ ] I have checked for redundant or commented out code
- [ ] I have commented my code where I can't make it self-documenting
- [ ] I have made corresponding changes to the documentation
- [ ] I have added any appropriate tests
