### PR TITLE
move allowlist to secrets block

### DIFF
--- a/data/nullify.yaml
+++ b/data/nullify.yaml
@@ -41,3 +41,13 @@ dependencies:
     - cve: CVE-2021-1234
       reason: This is a false positive
       expiry: "2021-12-31"
+secrets:
+  ignore:
+    - value: mocksecret123
+      reason: This is a test secret, it has no access to anything
+      paths: [ "**/tests/*" ]
+    - pattern: id[0-9]+
+      reason: These are not secrets, they are internal identifiers
+    - value: actualsecret123
+      reason: We can't remove this right now but we should
+      expiry: "2021-12-31"

--- a/pkg/models/config.go
+++ b/pkg/models/config.go
@@ -5,8 +5,8 @@ type Configuration struct {
 	IgnoreDirs             []string                         `yaml:"ignore_dirs,omitempty"`
 	IgnorePaths            []string                         `yaml:"ignore_paths,omitempty"`
 	SecretsWhitelist       []string                         `yaml:"secrets_whitelist,omitempty"` // TODO deprecate
-	SecretsAllowlist       []string                         `yaml:"secrets_allowlist,omitempty"`
 	Dependencies           Dependencies                     `yaml:"dependencies,omitempty"`
+	Secrets                Secrets                          `yaml:"secrets,omitempty"`
 	Notifications          map[string]Notification          `yaml:"notifications,omitempty"`
 	ScheduledNotifications map[string]ScheduledNotification `yaml:"scheduled_notifications,omitempty"`
 }

--- a/pkg/models/secrets.go
+++ b/pkg/models/secrets.go
@@ -1,0 +1,14 @@
+package models
+
+type Secrets struct {
+	Ignore []SecretsIgnore `yaml:"ignore,omitempty"`
+}
+
+type SecretsIgnore struct {
+	Value   string   `yaml:"value,omitempty"`
+	Pattern string   `yaml:"pattern,omitempty"`
+	Reason  string   `yaml:"reason,omitempty"`
+	Expiry  string   `yaml:"expiry,omitempty"`
+	Dirs    []string `yaml:"dirs,omitempty"`
+	Paths   []string `yaml:"paths,omitempty"`
+}

--- a/pkg/parser/parse_test.go
+++ b/pkg/parser/parse_test.go
@@ -28,7 +28,9 @@ func TestParseConfiguration(t *testing.T) {
 				IgnoreDirs:        nil,
 				IgnorePaths:       nil,
 				SecretsWhitelist:  nil,
-				SecretsAllowlist:  nil,
+				Secrets: models.Secrets{
+					Ignore: nil,
+				},
 			},
 		},
 		{
@@ -39,7 +41,16 @@ func TestParseConfiguration(t *testing.T) {
 				IgnoreDirs:        []string{"data"},
 				IgnorePaths:       []string{"*d"},
 				SecretsWhitelist:  []string{"secretPassword", "superSecretPassword"},
-				SecretsAllowlist:  []string{"secretPassword", "superSecretPassword"},
+				Secrets: models.Secrets{
+					Ignore: []models.SecretsIgnore{
+						{
+							Value: "secretPassword",
+						},
+						{
+							Value: "superSecretPassword",
+						},
+					},
+				},
 			},
 		},
 		{
@@ -50,7 +61,9 @@ func TestParseConfiguration(t *testing.T) {
 				IgnoreDirs:        nil,
 				IgnorePaths:       nil,
 				SecretsWhitelist:  nil,
-				SecretsAllowlist:  nil,
+				Secrets: models.Secrets{
+					Ignore: nil,
+				},
 			},
 		},
 		{
@@ -61,7 +74,9 @@ func TestParseConfiguration(t *testing.T) {
 				IgnoreDirs:        nil,
 				IgnorePaths:       nil,
 				SecretsWhitelist:  nil,
-				SecretsAllowlist:  nil,
+				Secrets: models.Secrets{
+					Ignore: nil,
+				},
 			},
 		},
 		{
@@ -72,7 +87,13 @@ func TestParseConfiguration(t *testing.T) {
 				IgnoreDirs:        nil,
 				IgnorePaths:       nil,
 				SecretsWhitelist:  []string{"password"},
-				SecretsAllowlist:  []string{"password"},
+				Secrets: models.Secrets{
+					Ignore: []models.SecretsIgnore{
+						{
+							Value: "password",
+						},
+					},
+				},
 			},
 		},
 		{
@@ -83,7 +104,9 @@ func TestParseConfiguration(t *testing.T) {
 				IgnoreDirs:        nil,
 				IgnorePaths:       nil,
 				SecretsWhitelist:  nil,
-				SecretsAllowlist:  nil,
+				Secrets: models.Secrets{
+					Ignore: nil,
+				},
 			},
 		},
 		{
@@ -94,7 +117,9 @@ func TestParseConfiguration(t *testing.T) {
 				IgnoreDirs:        nil,
 				IgnorePaths:       nil,
 				SecretsWhitelist:  nil,
-				SecretsAllowlist:  nil,
+				Secrets: models.Secrets{
+					Ignore: nil,
+				},
 			},
 		},
 		{
@@ -105,7 +130,9 @@ func TestParseConfiguration(t *testing.T) {
 				IgnoreDirs:        nil,
 				IgnorePaths:       []string{"*d"},
 				SecretsWhitelist:  nil,
-				SecretsAllowlist:  nil,
+				Secrets: models.Secrets{
+					Ignore: nil,
+				},
 			},
 		},
 	} {

--- a/pkg/validator/whitelist_secrets.go
+++ b/pkg/validator/whitelist_secrets.go
@@ -10,7 +10,7 @@ func ValidateSecrets(config *models.Configuration) bool {
 		return true
 	}
 
-	if config.SecretsAllowlist == nil {
+	if config.Secrets.Ignore == nil {
 		return true
 	}
 

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -13,7 +13,24 @@ func TestIntegration(t *testing.T) {
 		SeverityThreshold: models.SeverityMedium,
 		IgnoreDirs:        []string{"dir1"},
 		IgnorePaths:       []string{"data/**/*"},
-		SecretsAllowlist:  []string{"secret123"},
+		Secrets: models.Secrets{
+			Ignore: []models.SecretsIgnore{
+				{
+					Value:  "mocksecret123",
+					Reason: "This is a test secret, it has no access to anything",
+					Paths:  []string{"**/tests/*"},
+				},
+				{
+					Pattern: "id[0-9]+",
+					Reason:  "These are not secrets, they are internal identifiers",
+				},
+				{
+					Value:  "actualsecret123",
+					Reason: "We can't remove this right now but we should",
+					Expiry: "2021-12-31",
+				},
+			},
+		},
 		Notifications: map[string]models.Notification{
 			"all-events-webhook": {
 				Events: models.NotificationEvents{

--- a/tests/nullify.yaml
+++ b/tests/nullify.yaml
@@ -42,3 +42,13 @@ dependencies:
     - cve: CVE-2021-1234
       reason: This is a false positive
       expiry: "2021-12-31"
+secrets:
+  ignore:
+    - value: mocksecret123
+      reason: This is a test secret, it has no access to anything
+      paths: [ "**/tests/*" ]
+    - pattern: id[0-9]+
+      reason: These are not secrets, they are internal identifiers
+    - value: actualsecret123
+      reason: We can't remove this right now but we should
+      expiry: "2021-12-31"

--- a/tests/nullify.yaml
+++ b/tests/nullify.yaml
@@ -3,8 +3,6 @@ ignore_dirs:
   - dir1
 ignore_paths:
   - data/**/*
-secrets_allowlist:
-  - secret123
 notifications:
   all-events-webhook:
     events:


### PR DESCRIPTION
## Description

All features have their own config file block so we should be consistent.
the old secrets_whitelist field is still there which we will deprecate at some point.
setting this as a minor because we never released secrets_allowlist.

## Checklist

- [ ] I have added one of the `patch`, `minor`, `major` or `no-release` labels
- [ ] I have linked an issue from this repository using the **Development** option
- [ ] I have performed a self-review of my own code
- [ ] I have checked for redundant or commented out code
- [ ] I have commented my code where I can't make it self-documenting
- [ ] I have made corresponding changes to the documentation
- [ ] I have added any appropriate tests
