### PR TITLE
add global only repository list for all relevant settings

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -8,7 +8,7 @@ import (
 )
 
 func main() {
-	config, err := parser.LoadFromFile("data/nullify.yaml")
+	config, err := parser.LoadFromFile("examples/nullify.yaml")
 	if err != nil {
 		panic(err)
 	}

--- a/examples/nullify.yaml
+++ b/examples/nullify.yaml
@@ -1,6 +1,6 @@
 severity_threshold: medium
 ignore_dirs:
-  - data
+  - dir1
 ignore_paths:
   - data/**/*
 notifications:
@@ -8,7 +8,7 @@ notifications:
     events:
       all:
         minimum_severity: high
-        secret_types: [ssh_key]
+        secret_types: [ ssh_key ]
     targets:
       webhook:
         urls: [ https://webhook.site/123456 ]
@@ -17,30 +17,41 @@ notifications:
       new_code_findings:
         minimum_severity: high
       new_secret_findings:
-        types: [ssh_key]
+        types: [ ssh_key ]
       new_dependency_findings:
         minimum_severity: high
     targets:
       slack:
         channels: [ "123456" ]
       email:
-        emails: [ notifications@nullify.ai, noreply@nullify.ai ]
+        addresses: [ notifications@nullify.ai, noreply@nullify.ai ]
+    repositories:
+      - config-file-parser
+      - dast-action
+      - cli
 scheduled_notifications:
   new-findings:
-    schedule: "* * * * *"
+    schedule: "0 0 * * *"
     topics:
       all: true
     targets:
-      email:
-        addresses:
-          - monitoring@nullify.ai
       slack:
-        channel: "123456"
+        channels: [ "123456" ]
+      email:
+        addresses: [ notifications@nullify.ai, noreply@nullify.ai ]
+    repositories:
+      - config-file-parser
+      - dast-action
+      - cli
 code:
   ignore:
     - cwes: [ 589 ] # Potential HTTP request made with variable url
       reason: HTTP requests with variables in tests don't matter
-      paths: "**/tests/*"
+      paths: [ "**/tests/*" ]
+      repositories:
+        - config-file-parser
+        - dast-action
+        - cli
     - rule_ids: [ python-sql-injection ]
       reason: This code won't be going live until next year but we should fix it before then
       expiry: "2021-12-31"
@@ -49,6 +60,12 @@ dependencies:
     - cve: CVE-2021-1234
       reason: This is a false positive
       expiry: "2021-12-31"
+    - cve: CVE-2021-5678
+      reason: This isn't exploitable in client applications
+      expiry: "2021-12-31"
+      repositories:
+        - dast-action
+        - cli
 secrets:
   ignore:
     - value: mocksecret123

--- a/pkg/models/code.go
+++ b/pkg/models/code.go
@@ -11,4 +11,7 @@ type CodeIgnore struct {
 	Dirs    []string `yaml:"dirs,omitempty"`
 	Paths   []string `yaml:"paths,omitempty"`
 	Expiry  string   `yaml:"expiry,omitempty"`
+
+	// global config only
+	Repositories []string `yaml:"repositories,omitempty"`
 }

--- a/pkg/models/dependencies.go
+++ b/pkg/models/dependencies.go
@@ -10,4 +10,7 @@ type DependenciesIgnore struct {
 	Expiry string   `yaml:"expiry,omitempty"`
 	Dirs   []string `yaml:"dirs,omitempty"`
 	Paths  []string `yaml:"paths,omitempty"`
+
+	// global config only
+	Repositories []string `yaml:"repositories,omitempty"`
 }

--- a/pkg/models/notifications.go
+++ b/pkg/models/notifications.go
@@ -3,4 +3,7 @@ package models
 type Notification struct {
 	Events  NotificationEvents  `yaml:"events,omitempty"`
 	Targets NotificationTargets `yaml:"targets,omitempty"`
+
+	// global config only
+	Repositories []string `yaml:"repositories,omitempty"`
 }

--- a/pkg/models/scheduled_notifications.go
+++ b/pkg/models/scheduled_notifications.go
@@ -13,6 +13,9 @@ type ScheduledNotification struct {
 	Schedule string                       `yaml:"schedule,omitempty"`
 	Topics   ScheduledNotificationTopics  `yaml:"topics,omitempty"`
 	Targets  ScheduledNotificationTargets `yaml:"targets,omitempty"`
+
+	// global config only
+	Repositories []string `yaml:"repositories,omitempty"`
 }
 
 type ScheduledNotificationTopics struct {

--- a/pkg/models/secrets.go
+++ b/pkg/models/secrets.go
@@ -11,4 +11,7 @@ type SecretsIgnore struct {
 	Expiry  string   `yaml:"expiry,omitempty"`
 	Dirs    []string `yaml:"dirs,omitempty"`
 	Paths   []string `yaml:"paths,omitempty"`
+
+	// global config only
+	Repositories []string `yaml:"repositories,omitempty"`
 }

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -65,6 +65,11 @@ func TestIntegration(t *testing.T) {
 						Addresses: []string{"notifications@nullify.ai", "noreply@nullify.ai"},
 					},
 				},
+				Repositories: []string{
+					"config-file-parser",
+					"dast-action",
+					"cli",
+				},
 			},
 		},
 		ScheduledNotifications: map[string]models.ScheduledNotification{
@@ -81,6 +86,11 @@ func TestIntegration(t *testing.T) {
 						Channels: []string{"123456"},
 					},
 				},
+				Repositories: []string{
+					"config-file-parser",
+					"dast-action",
+					"cli",
+				},
 			},
 		},
 		Code: models.Code{
@@ -89,6 +99,11 @@ func TestIntegration(t *testing.T) {
 					CWEs:   []int{589},
 					Reason: "HTTP requests with variables in tests don't matter",
 					Paths:  []string{"**/tests/*"},
+					Repositories: []string{
+						"config-file-parser",
+						"dast-action",
+						"cli",
+					},
 				},
 				{
 					RuleIDs: []string{"python-sql-injection"},
@@ -103,6 +118,15 @@ func TestIntegration(t *testing.T) {
 					CVE:    "CVE-2021-1234",
 					Reason: "This is a false positive",
 					Expiry: "2021-12-31",
+				},
+				{
+					CVE:    "CVE-2021-5678",
+					Reason: "This isn't exploitable in client applications",
+					Expiry: "2021-12-31",
+					Repositories: []string{
+						"dast-action",
+						"cli",
+					},
 				},
 			},
 		},

--- a/tests/nullify.yaml
+++ b/tests/nullify.yaml
@@ -8,7 +8,7 @@ notifications:
     events:
       all:
         minimum_severity: high
-        secret_types: [ssh_key]
+        secret_types: [ ssh_key ]
     targets:
       webhook:
         urls: [ https://webhook.site/123456 ]

--- a/tests/nullify.yaml
+++ b/tests/nullify.yaml
@@ -25,6 +25,10 @@ notifications:
         channels: [ "123456" ]
       email:
         addresses: [ notifications@nullify.ai, noreply@nullify.ai ]
+    repositories:
+      - config-file-parser
+      - dast-action
+      - cli
 scheduled_notifications:
   new-findings:
     schedule: "0 0 * * *"
@@ -35,11 +39,19 @@ scheduled_notifications:
         channels: [ "123456" ]
       email:
         addresses: [ notifications@nullify.ai, noreply@nullify.ai ]
+    repositories:
+      - config-file-parser
+      - dast-action
+      - cli
 code:
   ignore:
     - cwes: [ 589 ] # Potential HTTP request made with variable url
       reason: HTTP requests with variables in tests don't matter
       paths: [ "**/tests/*" ]
+      repositories:
+        - config-file-parser
+        - dast-action
+        - cli
     - rule_ids: [ python-sql-injection ]
       reason: This code won't be going live until next year but we should fix it before then
       expiry: "2021-12-31"
@@ -48,6 +60,12 @@ dependencies:
     - cve: CVE-2021-1234
       reason: This is a false positive
       expiry: "2021-12-31"
+    - cve: CVE-2021-5678
+      reason: This isn't exploitable in client applications
+      expiry: "2021-12-31"
+      repositories:
+        - dast-action
+        - cli
 secrets:
   ignore:
     - value: mocksecret123


### PR DESCRIPTION
## Description

In the global config file e.g. .github-private repository, we want to have settings applicable to a subset of the repositories.

## Checklist

- [ ] I have added one of the `patch`, `minor`, `major` or `no-release` labels
- [ ] I have linked an issue from this repository using the **Development** option
- [ ] I have performed a self-review of my own code
- [ ] I have checked for redundant or commented out code
- [ ] I have commented my code where I can't make it self-documenting
- [ ] I have made corresponding changes to the documentation
- [ ] I have added any appropriate tests
