### PR TITLE
Converting fails build to a pointer

### DIFF
--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -1,7 +1,7 @@
 package models
 
 type Configuration struct {
-	FailBuilds             bool                             `yaml:"fail_builds,omitempty"`
+	FailBuilds             *bool                            `yaml:"fail_builds,omitempty"`
 	SeverityThreshold      string                           `yaml:"severity_threshold,omitempty"`
 	IgnoreDirs             []string                         `yaml:"ignore_dirs,omitempty"`
 	IgnorePaths            []string                         `yaml:"ignore_paths,omitempty"`

--- a/pkg/parser/defaults.go
+++ b/pkg/parser/defaults.go
@@ -6,7 +6,6 @@ const DefaultSeverityThreshold = models.SeverityMedium
 
 func NewDefaultConfig() *models.Configuration {
 	return &models.Configuration{
-		FailBuilds:             false,
 		SeverityThreshold:      DefaultSeverityThreshold,
 		IgnoreDirs:             []string{},
 		IgnorePaths:            []string{},

--- a/tests/empty_fail_build.yaml
+++ b/tests/empty_fail_build.yaml
@@ -1,0 +1,79 @@
+severity_threshold: medium
+ignore_dirs:
+  - dir1
+ignore_paths:
+  - data/**/*
+notifications:
+  all-events-webhook:
+    events:
+      all:
+        minimum_severity: high
+        secret_types: [ ssh_key ]
+    targets:
+      webhook:
+        urls: [ https://webhook.site/123456 ]
+  findings-to-slack-and-email:
+    events:
+      new_code_findings:
+        minimum_severity: high
+      new_secret_findings:
+        types: [ ssh_key ]
+      new_dependency_findings:
+        minimum_severity: high
+    targets:
+      slack:
+        channels: [ "123456" ]
+      email:
+        addresses: [ notifications@nullify.ai, noreply@nullify.ai ]
+    repositories:
+      - config-file-parser
+      - dast-action
+      - cli
+scheduled_notifications:
+  new-findings:
+    schedule: "0 0 * * *"
+    topics:
+      all: true
+    targets:
+      slack:
+        channels: [ "123456" ]
+      email:
+        addresses: [ notifications@nullify.ai, noreply@nullify.ai ]
+    repositories:
+      - config-file-parser
+      - dast-action
+      - cli
+code:
+  ignore:
+    - cwes: [ 589 ] # Potential HTTP request made with variable url
+      reason: HTTP requests with variables in tests don't matter
+      paths: [ "**/tests/*" ]
+      repositories:
+        - config-file-parser
+        - dast-action
+        - cli
+    - rule_ids: [ python-sql-injection ]
+      reason: This code won't be going live until next year but we should fix it before then
+      expiry: "2021-12-31"
+dependencies:
+  ignore:
+    - cve: CVE-2021-1234
+      reason: This is a false positive
+      expiry: "2021-12-31"
+    - cve: CVE-2021-5678
+      reason: This isn't exploitable in client applications
+      expiry: "2021-12-31"
+      repositories:
+        - dast-action
+        - cli
+secrets:
+  ignore:
+    - value: mocksecret123
+      reason: This is a test secret, it has no access to anything
+      paths: [ "**/tests/*" ]
+    - pattern: id[0-9]+
+      reason: These are not secrets, they are internal identifiers
+    - value: actualsecret123
+      reason: We can't remove this right now but we should
+      expiry: "2021-12-31"
+secrets_whitelist: ["abcd1234"]

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -10,8 +10,9 @@ import (
 )
 
 func TestIntegration(t *testing.T) {
+	fail := true
 	expectedConfig := &models.Configuration{
-		FailBuilds:        true,
+		FailBuilds:        &fail,
 		SeverityThreshold: models.SeverityMedium,
 		IgnoreDirs:        []string{"dir1"},
 		IgnorePaths:       []string{"data/**/*"},
@@ -136,6 +137,139 @@ func TestIntegration(t *testing.T) {
 	}
 
 	config, err := parser.LoadFromFile("nullify.yaml")
+	require.NoError(t, err)
+
+	require.Equal(t, expectedConfig, config)
+	require.True(t, validator.ValidateConfig(config))
+}
+
+func TestEmptyFailsBuildField(t *testing.T) {
+	expectedConfig := &models.Configuration{
+		FailBuilds:        nil,
+		SeverityThreshold: models.SeverityMedium,
+		IgnoreDirs:        []string{"dir1"},
+		IgnorePaths:       []string{"data/**/*"},
+		SecretsWhitelist:  []string{"abcd1234"},
+		Secrets: models.Secrets{
+			Ignore: []models.SecretsIgnore{
+				{
+					Value:  "mocksecret123",
+					Reason: "This is a test secret, it has no access to anything",
+					Paths:  []string{"**/tests/*"},
+				},
+				{
+					Pattern: "id[0-9]+",
+					Reason:  "These are not secrets, they are internal identifiers",
+				},
+				{
+					Value:  "actualsecret123",
+					Reason: "We can't remove this right now but we should",
+					Expiry: "2021-12-31",
+				},
+			},
+		},
+		Notifications: map[string]models.Notification{
+			"all-events-webhook": {
+				Events: models.NotificationEvents{
+					All: &models.NotificationEventAll{
+						MinimumSeverity: models.SeverityHigh,
+						SecretTypes:     []string{"ssh_key"},
+					},
+				},
+				Targets: models.NotificationTargets{
+					Webhook: &models.NotificationTargetWebhook{
+						URLs: []string{"https://webhook.site/123456"},
+					},
+				},
+			},
+			"findings-to-slack-and-email": {
+				Events: models.NotificationEvents{
+					NewCodeFindings: &models.NotificationEventNewCodeFindings{
+						MinimumSeverity: models.SeverityHigh,
+					},
+					NewSecretFindings: &models.NotificationEventNewSecretFindings{
+						Types: []string{"ssh_key"},
+					},
+					NewDependencyFindings: &models.NotificationEventNewDependencyFindings{
+						MinimumSeverity: models.SeverityHigh,
+					},
+				},
+				Targets: models.NotificationTargets{
+					Slack: &models.NotificationTargetSlack{
+						Channels: []string{"123456"},
+					},
+					Email: &models.NotificationTargetEmail{
+						Addresses: []string{"notifications@nullify.ai", "noreply@nullify.ai"},
+					},
+				},
+				Repositories: []string{
+					"config-file-parser",
+					"dast-action",
+					"cli",
+				},
+			},
+		},
+		ScheduledNotifications: map[string]models.ScheduledNotification{
+			"new-findings": {
+				Schedule: "0 0 * * *",
+				Topics: models.ScheduledNotificationTopics{
+					All: true,
+				},
+				Targets: models.ScheduledNotificationTargets{
+					Email: &models.ScheduledNotificationTargetEmail{
+						Addresses: []string{"notifications@nullify.ai", "noreply@nullify.ai"},
+					},
+					Slack: &models.ScheduledNotificationTargetSlack{
+						Channels: []string{"123456"},
+					},
+				},
+				Repositories: []string{
+					"config-file-parser",
+					"dast-action",
+					"cli",
+				},
+			},
+		},
+		Code: models.Code{
+			Ignore: []models.CodeIgnore{
+				{
+					CWEs:   []int{589},
+					Reason: "HTTP requests with variables in tests don't matter",
+					Paths:  []string{"**/tests/*"},
+					Repositories: []string{
+						"config-file-parser",
+						"dast-action",
+						"cli",
+					},
+				},
+				{
+					RuleIDs: []string{"python-sql-injection"},
+					Reason:  "This code won't be going live until next year but we should fix it before then",
+					Expiry:  "2021-12-31",
+				},
+			},
+		},
+		Dependencies: models.Dependencies{
+			Ignore: []models.DependenciesIgnore{
+				{
+					CVE:    "CVE-2021-1234",
+					Reason: "This is a false positive",
+					Expiry: "2021-12-31",
+				},
+				{
+					CVE:    "CVE-2021-5678",
+					Reason: "This isn't exploitable in client applications",
+					Expiry: "2021-12-31",
+					Repositories: []string{
+						"dast-action",
+						"cli",
+					},
+				},
+			},
+		},
+	}
+
+	config, err := parser.LoadFromFile("empty_fail_build.yaml")
 	require.NoError(t, err)
 
 	require.Equal(t, expectedConfig, config)


### PR DESCRIPTION
## Description

Converting fails build to a pointer so we know when the field is set or not
- set to either true or false
- set to nil means the field was not set

## Linked Issues & PRs

- resolves <insert-issue-link>
- relates to <insert-pr-link>

[GitHub Issue Linking Docs](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)

## Checklist

- [x] I have added one of the `patch`, `minor`, `major` or `no-release` labels
- [ ] I have linked an issue from this repository using the **Development** option
- [ ] I have performed a self-review of my own code
- [ ] I have checked for redundant or commented out code
- [ ] I have commented my code where I can't make it self-documenting
- [ ] I have made corresponding changes to the documentation
- [ ] I have added any appropriate tests
