### PR TITLE
include secrets whitelist in merge

### DIFF
--- a/pkg/merger/merger.go
+++ b/pkg/merger/merger.go
@@ -29,6 +29,7 @@ func MergeConfigFiles(
 		config.Code.Ignore = globalConfig.Code.Ignore
 		config.Dependencies.Ignore = globalConfig.Dependencies.Ignore
 		config.Secrets.Ignore = globalConfig.Secrets.Ignore
+		config.SecretsWhitelist = globalConfig.SecretsWhitelist
 
 		if len(globalConfig.Notifications) > 0 && config.Notifications == nil {
 			config.Notifications = globalConfig.Notifications
@@ -79,6 +80,10 @@ func MergeConfigFiles(
 
 	if len(repoConfig.Secrets.Ignore) > 0 {
 		config.Secrets.Ignore = repoConfig.Secrets.Ignore
+	}
+
+	if len(repoConfig.SecretsWhitelist) > 0 {
+		config.SecretsWhitelist = repoConfig.SecretsWhitelist
 	}
 
 	if len(repoConfig.Notifications) > 0 && config.Notifications == nil {


### PR DESCRIPTION
## Description

Include secrets whitelist in config file merge.
we will deprecate it later once we can detect all customers are migrated.

## Checklist

- [ ] I have added one of the `patch`, `minor`, `major` or `no-release` labels
- [ ] I have linked an issue from this repository using the **Development** option
- [ ] I have performed a self-review of my own code
- [ ] I have checked for redundant or commented out code
- [ ] I have commented my code where I can't make it self-documenting
- [ ] I have made corresponding changes to the documentation
- [ ] I have added any appropriate tests
