### PR TITLE
use consistent max_pull_request prefix for the 2 auto-fix pr creation limits

### DIFF
--- a/examples/nullify.yaml
+++ b/examples/nullify.yaml
@@ -48,8 +48,8 @@ scheduled_notifications:
 code:
   auto_fix:
     enabled: true
-    max_open_pull_requests: 2
-    pull_requests_creation_rate:
+    max_pull_requests_open: 2
+    max_pull_request_creation_rate:
       count: 1
       period: 1d
   ignore:
@@ -64,6 +64,12 @@ code:
       reason: This code won't be going live until next year but we should fix it before then
       expiry: "2021-12-31"
 dependencies:
+  auto_fix:
+    enabled: true
+    max_pull_requests_open: 2
+    max_pull_request_creation_rate:
+      count: 1
+      period: 1d
   ignore:
     - cves: [ CVE-2021-1234 ]
       reason: This is a false positive

--- a/examples/nullify.yaml
+++ b/examples/nullify.yaml
@@ -51,7 +51,7 @@ code:
     max_pull_requests_open: 2
     max_pull_request_creation_rate:
       count: 1
-      period: 1d
+      days: 1
   ignore:
     - cwes: [ 589 ] # Potential HTTP request made with variable url
       reason: HTTP requests with variables in tests don't matter
@@ -69,7 +69,7 @@ dependencies:
     max_pull_requests_open: 2
     max_pull_request_creation_rate:
       count: 1
-      period: 1d
+      days: 1
   ignore:
     - cves: [ CVE-2021-1234 ]
       reason: This is a false positive

--- a/pkg/models/autofix.go
+++ b/pkg/models/autofix.go
@@ -2,11 +2,11 @@ package models
 
 type AutoFix struct {
 	Enabled                    bool                            `yaml:"enabled,omitempty"`
-	MaxPullRequestsOpen        int                             `yaml:"max_pull_requests_open,omitempty"`
+	MaxPullRequestsOpen        *int                            `yaml:"max_pull_requests_open,omitempty"`
 	MaxPullRequestCreationRate *AutoFixPullRequestCreationRate `yaml:"max_pull_request_creation_rate,omitempty"`
 }
 
 type AutoFixPullRequestCreationRate struct {
-	Count  int    `yaml:"count,omitempty"`
-	Period string `yaml:"period,omitempty"`
+	Count int `yaml:"count,omitempty"`
+	Days  int `yaml:"days,omitempty"`
 }

--- a/pkg/models/autofix.go
+++ b/pkg/models/autofix.go
@@ -1,9 +1,9 @@
 package models
 
 type AutoFix struct {
-	Enabled                 bool                            `yaml:"enabled,omitempty"`
-	MaxOpenPullRequests     int                             `yaml:"max_open_pull_requests,omitempty"`
-	PullRequestCreationRate *AutoFixPullRequestCreationRate `yaml:"pull_request_creation_rate,omitempty"`
+	Enabled                    bool                            `yaml:"enabled,omitempty"`
+	MaxPullRequestsOpen        int                             `yaml:"max_pull_requests_open,omitempty"`
+	MaxPullRequestCreationRate *AutoFixPullRequestCreationRate `yaml:"max_pull_request_creation_rate,omitempty"`
 }
 
 type AutoFixPullRequestCreationRate struct {

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -24,3 +24,7 @@ func (c *Configuration) GetFailBuilds() bool {
 
 	return *c.FailBuilds
 }
+
+func Int(i int) *int {
+	return &i
+}

--- a/pkg/validator/autofix.go
+++ b/pkg/validator/autofix.go
@@ -1,8 +1,6 @@
 package validator
 
 import (
-	"time"
-
 	"github.com/nullify-platform/config-file-parser/pkg/models"
 )
 
@@ -15,18 +13,21 @@ func validateAutoFix(autofix *models.AutoFix) bool {
 		return true
 	}
 
-	if autofix.MaxPullRequestsOpen < 0 {
-		return false
+	if autofix.MaxPullRequestsOpen != nil {
+		if *autofix.MaxPullRequestsOpen < 0 {
+			return false
+		}
 	}
 
-	if autofix.MaxPullRequestCreationRate == nil {
-		return true
+	if autofix.MaxPullRequestCreationRate != nil {
+		if autofix.MaxPullRequestCreationRate.Count < 0 {
+			return false
+		}
+
+		if autofix.MaxPullRequestCreationRate.Days < 0 {
+			return false
+		}
 	}
 
-	if autofix.MaxPullRequestCreationRate.Count < 0 {
-		return false
-	}
-
-	_, err := time.ParseDuration(autofix.MaxPullRequestCreationRate.Period)
-	return err == nil
+	return true
 }

--- a/pkg/validator/autofix.go
+++ b/pkg/validator/autofix.go
@@ -15,18 +15,18 @@ func validateAutoFix(autofix *models.AutoFix) bool {
 		return true
 	}
 
-	if autofix.MaxOpenPullRequests < 0 {
+	if autofix.MaxPullRequestsOpen < 0 {
 		return false
 	}
 
-	if autofix.PullRequestCreationRate == nil {
+	if autofix.MaxPullRequestCreationRate == nil {
 		return true
 	}
 
-	if autofix.PullRequestCreationRate.Count < 0 {
+	if autofix.MaxPullRequestCreationRate.Count < 0 {
 		return false
 	}
 
-	_, err := time.ParseDuration(autofix.PullRequestCreationRate.Period)
+	_, err := time.ParseDuration(autofix.MaxPullRequestCreationRate.Period)
 	return err == nil
 }

--- a/pkg/validator/autofix_test.go
+++ b/pkg/validator/autofix_test.go
@@ -1,0 +1,55 @@
+package validator
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/nullify-platform/config-file-parser/pkg/models"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidAutoFix(t *testing.T) {
+	for _, scenario := range []struct {
+		name     string
+		config   *models.Configuration
+		expected bool
+	}{
+		{
+			name:     "empty config",
+			config:   &models.Configuration{},
+			expected: true,
+		},
+		{
+			name: "valid",
+			config: &models.Configuration{
+				Code: models.Code{
+					AutoFix: models.AutoFix{
+						Enabled:             true,
+						MaxPullRequestsOpen: models.Int(2),
+						MaxPullRequestCreationRate: &models.AutoFixPullRequestCreationRate{
+							Count: 1,
+							Days:  1,
+						},
+					},
+				},
+				Dependencies: models.Dependencies{
+					AutoFix: models.AutoFix{
+						Enabled:             true,
+						MaxPullRequestsOpen: models.Int(2),
+						MaxPullRequestCreationRate: &models.AutoFixPullRequestCreationRate{
+							Count: 1,
+							Days:  1,
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+	} {
+		t.Run(scenario.name, func(t *testing.T) {
+			isValid := ValidateAutoFix(scenario.config)
+			assert.Equalf(t, isValid, scenario.expected, fmt.Sprintf("failed test: %s\n", scenario.name))
+		})
+	}
+}

--- a/pkg/validator/notifications_test.go
+++ b/pkg/validator/notifications_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestValidEmails(t *testing.T) {
+func TestValidNotifications(t *testing.T) {
 	for _, scenario := range []struct {
 		name     string
 		config   *models.Configuration


### PR DESCRIPTION
## Description

after a 2nd look at it, i think having a consistent `max_pull_request` prefix for both auto-fix pull request creation limits is better.

Also change `period` to `days` because time.ParseDuration only does units up to hours and our most common unit will probably be days, if not weeks.

## Checklist

- [ ] I have added one of the `patch`, `minor`, `major` or `no-release` labels
- [ ] I have linked an issue from this repository using the **Development** option
- [ ] I have performed a self-review of my own code
- [ ] I have checked for redundant or commented out code
- [ ] I have commented my code where I can't make it self-documenting
- [ ] I have made corresponding changes to the documentation
- [ ] I have added any appropriate tests
