### PR TITLE
NUL-98 add autofix `scripts` to for lint, compile, test

### DIFF
--- a/pkg/models/autofix.go
+++ b/pkg/models/autofix.go
@@ -4,9 +4,18 @@ type AutoFix struct {
 	Enabled                    bool                            `yaml:"enabled,omitempty"`
 	MaxPullRequestsOpen        *int                            `yaml:"max_pull_requests_open,omitempty"`
 	MaxPullRequestCreationRate *AutoFixPullRequestCreationRate `yaml:"max_pull_request_creation_rate,omitempty"`
+	Scripts                    *AutoFixScripts                 `yaml:"scripts,omitempty"`
 }
 
 type AutoFixPullRequestCreationRate struct {
 	Count int `yaml:"count,omitempty"`
 	Days  int `yaml:"days,omitempty"`
+}
+
+type AutoFixScripts struct {
+	// docker image - run locally if empty
+	Image   string `yaml:"image,omitempty"`
+	Lint    string `yaml:"lint,omitempty"`
+	Compile string `yaml:"compile,omitempty"`
+	Test    string `yaml:"test,omitempty"`
 }


### PR DESCRIPTION
## Description

NUL-98 add autofix `scripts` to for lint, compile, test

## Linked Issues & PRs

- towards to https://linear.app/nullify-ai/issue/NUL-98/add-self-checking-with-the-llm-to-verify-the-sast-fixes

## Checklist

- [x] I have added one of the `patch`, `minor`, `major` or `no-release` labels
- [x] I have linked an issue from this repository using the **Development** option
- [x] I have performed a self-review of my own code
- [ ] I have checked for redundant or commented out code
- [ ] I have commented my code where I can't make it self-documenting
- [ ] I have made corresponding changes to the documentation
- [ ] I have added any appropriate tests
