### PR TITLE
feat(NUL-649): add the sha256 matcher for secrets allowlisting

### DIFF
--- a/examples/nullify.yaml
+++ b/examples/nullify.yaml
@@ -90,6 +90,8 @@ secrets:
     - value: actualsecret123
       reason: We can't remove this right now but we should
       expiry: "2021-12-31"
+    - sha256: 87cbebfeebc05f7c54ac9336c4b4bbec831227a641951a4bde7edd56020f8590 # this is correct-horse-battery-staple
+      reason: This was allowlisted from the Nullify dashboard
 integrations:
   jira:
     disabled: true

--- a/pkg/models/secrets.go
+++ b/pkg/models/secrets.go
@@ -11,6 +11,7 @@ type SecretsIgnore struct {
 	// matchers
 	Value   string `yaml:"value,omitempty"`
 	Pattern string `yaml:"pattern,omitempty"`
+	SHA256  string `yaml:"sha256,omitempty"`
 
 	// global config only
 	Repositories []string `yaml:"repositories,omitempty"`


### PR DESCRIPTION
## Description

* add sha256 matcher for secrets, to support allowlisting from dashboard/API/sources where we don't have the underlying value

## Linked Issues & PRs

- resolves <insert-issue-link>
- relates to <insert-pr-link>

[GitHub Issue Linking Docs](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)

## Checklist

- [ ] I have added one of the `patch`, `minor`, `major` or `no-release` labels
- [ ] I have linked an issue from this repository using the **Development** option
- [ ] I have performed a self-review of my own code
- [ ] I have checked for redundant or commented out code
- [ ] I have commented my code where I can't make it self-documenting
- [ ] I have made corresponding changes to the documentation
- [ ] I have added any appropriate tests
