### PR TITLE
fix jira override behaviour

### DIFF
--- a/pkg/merger/merger.go
+++ b/pkg/merger/merger.go
@@ -50,6 +50,22 @@ func MergeConfigFiles(
 			if config.Integrations.Jira == nil {
 				config.Integrations.Jira = extraConfig.Integrations.Jira
 			} else {
+				if extraConfig.Integrations.Jira.ProjectKey != "" {
+					config.Integrations.Jira.ProjectKey = extraConfig.Integrations.Jira.ProjectKey
+				}
+				if extraConfig.Integrations.Jira.IssueType != "" {
+					config.Integrations.Jira.IssueType = extraConfig.Integrations.Jira.IssueType
+				}
+				if extraConfig.Integrations.Jira.OnFixTransition != "" {
+					config.Integrations.Jira.OnFixTransition = extraConfig.Integrations.Jira.OnFixTransition
+				}
+				if extraConfig.Integrations.Jira.Disabled {
+					config.Integrations.Jira.Disabled = extraConfig.Integrations.Jira.Disabled
+				}
+				if extraConfig.Integrations.Jira.SeverityThreshold != "" {
+					config.Integrations.Jira.SeverityThreshold = extraConfig.Integrations.Jira.SeverityThreshold
+				}
+
 				if extraConfig.Integrations.Jira.Priorities != nil {
 					config.Integrations.Jira.Priorities = extraConfig.Integrations.Jira.Priorities
 				}

--- a/pkg/merger/merger_test.go
+++ b/pkg/merger/merger_test.go
@@ -525,6 +525,36 @@ func TestMergeJira(t *testing.T) {
 			},
 		},
 		{
+			name: "Jira repo config with project key overriding",
+			globalConfig: &models.Configuration{
+				Integrations: models.Integrations{
+					Jira: &models.Jira{
+						ProjectKey: "projectkey1",
+						IssueType:  "issuetype1",
+					},
+				},
+			},
+			repoConfig: &models.Configuration{
+				Integrations: models.Integrations{
+					Jira: &models.Jira{
+						ProjectKey: "projectkey2",
+					},
+				},
+			},
+			expected: &models.Configuration{
+				EnablePullRequestReviews: models.Bool(true),
+				EnableIssueDashboards:    models.Bool(true),
+				SeverityThreshold:        parser.DefaultSeverityThreshold,
+				PriorityThreshold:        parser.DefaultPriorityThreshold,
+				Integrations: models.Integrations{
+					Jira: &models.Jira{
+						ProjectKey: "projectkey2",
+						IssueType:  "issuetype1",
+					},
+				},
+			},
+		},
+		{
 			name: "secrets custom patterns global",
 			globalConfig: &models.Configuration{
 				Secrets: models.Secrets{


### PR DESCRIPTION
## Description

If there is a global config file and repo config file, the repo config file is not overriding the global Jira settings. Only priorities and assignees were being overridden.

the fix allows project key, issue type etc to also be overriden if they are not empty strings

## Checklist

- [ ] I have added one of the `patch`, `minor`, `major` or `no-release` labels
- [ ] I have linked an issue from this repository using the **Development** option
- [ ] I have performed a self-review of my own code
- [ ] I have checked for redundant or commented out code
- [ ] I have commented my code where I can't make it self-documenting
- [ ] I have made corresponding changes to the documentation
- [ ] I have added any appropriate tests
