### PR TITLE
NUL-1459 add projects mapping for monorepo

### DIFF
--- a/examples/nullify.yaml
+++ b/examples/nullify.yaml
@@ -109,3 +109,28 @@ integrations:
     assignee:
       id: 123456:abcd1234-abcd-1234-abcd-abcde12345666
       name: John Smith
+projects:
+  frontend:
+    display_name: Frontend Application
+    path: frontend
+    type: react-app
+    description: "Frontend application for the web"
+  backend:
+    display_name: Backend API
+    path: backend
+    type: node-api
+    description: "Backend API server"
+  mobile:
+    display_name: Mobile Application
+    path: mobile
+    type: react-native-app
+    description: "Mobile application"
+  shared:
+    display_name: Shared Library
+    path: shared
+    type: library
+    description: "Shared utilities and libraries"
+  docs:
+    display_name: Documentation
+    path: docs/user-guide
+    description: "User guide documentation"

--- a/pkg/merger/merger.go
+++ b/pkg/merger/merger.go
@@ -137,6 +137,10 @@ func MergeConfigFiles(
 		for k, v := range extraConfig.ScheduledNotifications {
 			config.ScheduledNotifications[k] = v
 		}
+
+		if extraConfig.Projects != nil {
+			config.Projects = extraConfig.Projects
+		}
 	}
 
 	return &config

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -25,6 +25,15 @@ type Configuration struct {
 
 	// TODO deprecate
 	SecretsWhitelist []string `yaml:"secrets_whitelist,omitempty"`
+
+	Projects map[string]Project `yaml:"projects,omitempty"`
+}
+
+type Project struct {
+	DisplayName string `yaml:"display_name"`
+	Path        string `yaml:"path"`
+	Type        string `yaml:"type"`
+	Description string `yaml:"description"`
 }
 
 func (c *Configuration) GetEnableFailBuilds() bool {

--- a/pkg/parser/defaults.go
+++ b/pkg/parser/defaults.go
@@ -26,5 +26,6 @@ func NewDefaultConfig() *models.Configuration {
 		Notifications:          nil,
 		ScheduledNotifications: nil,
 		Integrations:           models.Integrations{},
+		Projects:               nil,
 	}
 }

--- a/pkg/validator/projects.go
+++ b/pkg/validator/projects.go
@@ -1,0 +1,19 @@
+package validator
+
+import (
+	"github.com/nullify-platform/config-file-parser/pkg/models"
+)
+
+func ValidateProjects(config *models.Configuration) bool {
+	if config.Projects == nil {
+		return true
+	}
+
+	for _, project := range config.Projects {
+		if project.Path == "" {
+			return false
+		}
+	}
+
+	return true
+}

--- a/pkg/validator/validate.go
+++ b/pkg/validator/validate.go
@@ -10,5 +10,6 @@ func ValidateConfig(config *models.Configuration) bool {
 		ValidateNotifications(config) &&
 		ValidateScheduledNotifications(config) &&
 		ValidatePaths(config) &&
-		ValidateAutoFix(config)
+		ValidateAutoFix(config) &&
+		ValidateProjects(config)
 }


### PR DESCRIPTION
## Description

add a mapping between projects and subdirectories. used for segregating a monorepo. 

## Checklist

- [ ] I have added one of the `patch`, `minor`, `major` or `no-release` labels
- [ ] I have linked an issue from this repository using the **Development** option
- [ ] I have performed a self-review of my own code
- [ ] I have checked for redundant or commented out code
- [ ] I have commented my code where I can't make it self-documenting
- [ ] I have made corresponding changes to the documentation
- [ ] I have added any appropriate tests
