### PR TITLE
fix: add empty string to valid severities

### DIFF
--- a/pkg/validator/severity.go
+++ b/pkg/validator/severity.go
@@ -6,6 +6,7 @@ import (
 )
 
 var validSeveritites = []string{
+	"",
 	models.SeverityLow,
 	models.SeverityMedium,
 	models.SeverityHigh,
@@ -24,6 +25,7 @@ func ValidateSeverityThreshold(config *models.Configuration) bool {
 }
 
 var validPriorities = []string{
+	"",
 	models.PriorityUrgent,
 	models.PriorityImportant,
 	models.PriorityMedium,

--- a/pkg/validator/severity_test.go
+++ b/pkg/validator/severity_test.go
@@ -17,7 +17,7 @@ func TestValidateSeverityThreshold(t *testing.T) {
 		{
 			name:     "empty configuration",
 			config:   &models.Configuration{},
-			expected: false,
+			expected: true,
 		},
 		{
 			name:     "default configuration",
@@ -27,7 +27,7 @@ func TestValidateSeverityThreshold(t *testing.T) {
 		{
 			name:     "empty SeverityThreshold",
 			config:   &models.Configuration{SeverityThreshold: ""},
-			expected: false,
+			expected: true,
 		},
 		{
 			name:     "SeverityLow",


### PR DESCRIPTION
## Description

there is a bug where the empty string and other valid config files are coming up as invalid. this behaviour is also inconsistent with the comment

`isValid := validator.ValidateConfig(parsedConfig)` returns false

## Checklist

- [ ] I have added one of the `patch`, `minor`, `major` or `no-release` labels
- [ ] I have linked an issue from this repository using the **Development** option
- [ ] I have performed a self-review of my own code
- [ ] I have checked for redundant or commented out code
- [ ] I have commented my code where I can't make it self-documenting
- [ ] I have made corresponding changes to the documentation
- [ ] I have added any appropriate tests
