### PR TITLE
add roleName to the config file parser

### DIFF
--- a/pkg/models/attack_surface.go
+++ b/pkg/models/attack_surface.go
@@ -12,6 +12,7 @@ type AttackSurface struct {
 
 type AWSIntegration struct {
 	Enable           bool      `yaml:"enable"`
+	RoleNameToAssume string    `yaml:"role_name_to_assume"`
 	PrimaryAccountID string    `yaml:"primary_account_id,omitempty"`
 	PrimaryRegion    string    `yaml:"primary_region,omitempty"`
 	TargetRegions    *[]string `yaml:"target_regions,omitempty"`

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -194,6 +194,7 @@ func TestIntegration(t *testing.T) {
 				PrimaryRegion:    "ap-southeast-2",
 				TargetRegions:    &[]string{"ap-southeast-2", "us-east-2"},
 				TargetAccounts:   &[]string{"123456789012", "123456789013"},
+				RoleNameToAssume: "nullify-role",
 			},
 		},
 	}

--- a/tests/nullify.yaml
+++ b/tests/nullify.yaml
@@ -116,6 +116,7 @@ attack_surface:
         methods: [POST]
   aws_integration:
     enable: true
+    role_name_to_assume: nullify-role
     primary_account_id: 123456789012
     primary_region: ap-southeast-2
     target_regions: [ap-southeast-2, us-east-2]


### PR DESCRIPTION
## Description

get the rolename from the config which will be used to assume across customer accounts