### PR TITLE
Attack surface monitoring: parity between includeOnly and ignore

### DIFF
--- a/examples/nullify.yaml
+++ b/examples/nullify.yaml
@@ -122,6 +122,8 @@ attack_surface:
   hosts: [example.com, prod.hosting.com, 10.11.12.13, 10.0.0.*]
   include_only:
     - hosts: [live.prod.hosting.com]
+      transport_protocols: [tcp]
+      ports: [80, 443]
       http:
         methods: [GET, POST]
         paths: [/main, /api/**/create]

--- a/pkg/merger/merger_test.go
+++ b/pkg/merger/merger_test.go
@@ -373,18 +373,20 @@ func TestMergeConfigFiles(t *testing.T) {
 					Enable:               true,
 					EnableDNSEnumeration: true,
 					Hosts:                []string{"example.com", "prod.hosting.com", "10.11.12.13", "10.0.0.*"},
-					IncludeOnly: []models.AttackSurfaceIncludeOnly{
+					IncludeOnly: []models.AttackSurfaceScopingRule{
 						{
-							Hosts: []string{"live.prod.hosting.com"},
-							HTTP: &models.HTTPAttackSurfaceIncludeOnly{
+							Hosts:              []string{"live.prod.hosting.com"},
+							TransportProtocols: []string{"tcp"},
+							Ports:              []string{"80", "443"},
+							HTTP: &models.HTTPAttackSurfaceScopingRuleHTTP{
 								Methods: []string{"GET", "POST"},
 								Paths:   []string{"/main", "/api/**/create"},
 							},
 						},
 					},
-					Ignore: []models.AttackSurfaceIgnore{
+					Ignore: []models.AttackSurfaceScopingRule{
 						{
-							HTTP: &models.HTTPAttackSurfaceIgnore{
+							HTTP: &models.HTTPAttackSurfaceScopingRuleHTTP{
 								Methods: []string{"DELETE"},
 							},
 						},
@@ -398,7 +400,7 @@ func TestMergeConfigFiles(t *testing.T) {
 						},
 						{
 							Hosts: []string{"dev.*", "staging.*"},
-							HTTP: &models.HTTPAttackSurfaceIgnore{
+							HTTP: &models.HTTPAttackSurfaceScopingRuleHTTP{
 								Paths:   []string{"/auth"},
 								Methods: []string{"POST"},
 							},
@@ -416,18 +418,20 @@ func TestMergeConfigFiles(t *testing.T) {
 					Enable:               true,
 					EnableDNSEnumeration: true,
 					Hosts:                []string{"example.com", "prod.hosting.com", "10.11.12.13", "10.0.0.*"},
-					IncludeOnly: []models.AttackSurfaceIncludeOnly{
+					IncludeOnly: []models.AttackSurfaceScopingRule{
 						{
-							Hosts: []string{"live.prod.hosting.com"},
-							HTTP: &models.HTTPAttackSurfaceIncludeOnly{
+							Hosts:              []string{"live.prod.hosting.com"},
+							TransportProtocols: []string{"tcp"},
+							Ports:              []string{"80", "443"},
+							HTTP: &models.HTTPAttackSurfaceScopingRuleHTTP{
 								Methods: []string{"GET", "POST"},
 								Paths:   []string{"/main", "/api/**/create"},
 							},
 						},
 					},
-					Ignore: []models.AttackSurfaceIgnore{
+					Ignore: []models.AttackSurfaceScopingRule{
 						{
-							HTTP: &models.HTTPAttackSurfaceIgnore{
+							HTTP: &models.HTTPAttackSurfaceScopingRuleHTTP{
 								Methods: []string{"DELETE"},
 							},
 						},
@@ -441,7 +445,7 @@ func TestMergeConfigFiles(t *testing.T) {
 						},
 						{
 							Hosts: []string{"dev.*", "staging.*"},
-							HTTP: &models.HTTPAttackSurfaceIgnore{
+							HTTP: &models.HTTPAttackSurfaceScopingRuleHTTP{
 								Paths:   []string{"/auth"},
 								Methods: []string{"POST"},
 							},

--- a/pkg/models/attack_surface.go
+++ b/pkg/models/attack_surface.go
@@ -5,29 +5,18 @@ type AttackSurface struct {
 	Enable               bool                       `yaml:"enable"`
 	EnableDNSEnumeration bool                       `yaml:"enable_dns_enumeration"`
 	Hosts                []string                   `yaml:"hosts,omitempty"`
-	IncludeOnly          []AttackSurfaceIncludeOnly `yaml:"include_only,omitempty"`
-	Ignore               []AttackSurfaceIgnore      `yaml:"ignore,omitempty"`
+	IncludeOnly          []AttackSurfaceScopingRule `yaml:"include_only,omitempty"`
+	Ignore               []AttackSurfaceScopingRule `yaml:"ignore,omitempty"`
 }
 
-type AttackSurfaceIncludeOnly struct {
-	Hosts []string                      `yaml:"hosts,omitempty"`
-	HTTP  *HTTPAttackSurfaceIncludeOnly `yaml:"http,omitempty"`
+type AttackSurfaceScopingRule struct {
+	Hosts              []string                          `yaml:"hosts,omitempty"`
+	TransportProtocols []string                          `yaml:"transport_protocols,omitempty"`
+	Ports              []string                          `yaml:"ports,omitempty"`
+	HTTP               *HTTPAttackSurfaceScopingRuleHTTP `yaml:"http,omitempty"`
 }
 
-type HTTPAttackSurfaceIncludeOnly struct {
-	Methods []string `yaml:"methods,omitempty"`
-	Paths   []string `yaml:"paths,omitempty"`
-}
-
-type AttackSurfaceIgnore struct {
-	// empty fields are equivalent to *
-	Hosts              []string                 `yaml:"hosts,omitempty"`
-	TransportProtocols []string                 `yaml:"transport_protocols,omitempty"`
-	Ports              []string                 `yaml:"ports,omitempty"`
-	HTTP               *HTTPAttackSurfaceIgnore `yaml:"http,omitempty"`
-}
-
-type HTTPAttackSurfaceIgnore struct {
+type HTTPAttackSurfaceScopingRuleHTTP struct {
 	Methods []string `yaml:"methods,omitempty"`
 	Paths   []string `yaml:"paths,omitempty"`
 }

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -165,18 +165,20 @@ func TestIntegration(t *testing.T) {
 			Enable:               true,
 			EnableDNSEnumeration: true,
 			Hosts:                []string{"example.com", "prod.hosting.com", "10.11.12.13", "10.0.0.*"},
-			IncludeOnly: []models.AttackSurfaceIncludeOnly{
+			IncludeOnly: []models.AttackSurfaceScopingRule{
 				{
-					Hosts: []string{"live.prod.hosting.com"},
-					HTTP: &models.HTTPAttackSurfaceIncludeOnly{
+					Hosts:              []string{"live.prod.hosting.com"},
+					TransportProtocols: []string{"tcp"},
+					Ports:              []string{"80", "443"},
+					HTTP: &models.HTTPAttackSurfaceScopingRuleHTTP{
 						Methods: []string{"GET", "POST"},
 						Paths:   []string{"/main", "/api/**/create"},
 					},
 				},
 			},
-			Ignore: []models.AttackSurfaceIgnore{
+			Ignore: []models.AttackSurfaceScopingRule{
 				{
-					HTTP: &models.HTTPAttackSurfaceIgnore{
+					HTTP: &models.HTTPAttackSurfaceScopingRuleHTTP{
 						Methods: []string{"DELETE"},
 					},
 				},
@@ -190,7 +192,7 @@ func TestIntegration(t *testing.T) {
 				},
 				{
 					Hosts: []string{"dev.*", "staging.*"},
-					HTTP: &models.HTTPAttackSurfaceIgnore{
+					HTTP: &models.HTTPAttackSurfaceScopingRuleHTTP{
 						Paths:   []string{"/auth"},
 						Methods: []string{"POST"},
 					},

--- a/tests/nullify.yaml
+++ b/tests/nullify.yaml
@@ -107,6 +107,8 @@ attack_surface:
   hosts: [example.com, prod.hosting.com, 10.11.12.13, 10.0.0.*]
   include_only:
     - hosts: [live.prod.hosting.com]
+      transport_protocols: [tcp]
+      ports: [80, 443]
       http:
         methods: [GET, POST]
         paths: [/main, /api/**/create]


### PR DESCRIPTION
## Description

Match parity betewen include and ignore rules (i.e. add transportProtocols and ports to include rules)

## Test Plan

Please include steps to test the change. Include screenshots if applicable.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have checked for redundant or commented out code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added any appropriate tests
