### PR TITLE
chore - keep old priorities for temporary backwards compatibility

### DIFF
--- a/pkg/models/priority.go
+++ b/pkg/models/priority.go
@@ -5,13 +5,25 @@ const (
 	PriorityImportant     string = "IMPORTANT"
 	PriorityInformational string = "INFORMATIONAL"
 	PriorityUnknown       string = "UNKNOWN"
+
+	// To be deprecated
+	PriorityNegligible string = "NEGIGIBLE"
+	PriorityLow        string = "LOW"
+	PriorityMedium     string = "MEDIUM"
+	// important is repeated
+	// urgent is repeated
 )
 
 var priorityToInt = map[string]int{
 	PriorityUnknown:       0,
 	PriorityInformational: 1,
-	PriorityImportant:     2,
-	PriorityUrgent:        3,
+	PriorityImportant:     4,
+	PriorityUrgent:        5,
+
+	// To be deprecated
+	PriorityNegligible: 1,
+	PriorityLow:        2,
+	PriorityMedium:     3,
 }
 
 func ComparePriority(priority1, priority2 string) int {
@@ -41,5 +53,18 @@ func ComparePriority(priority1, priority2 string) int {
 		return 1
 	} else {
 		return 0
+	}
+}
+
+func SeverityToPriority(severity string) string {
+	switch severity {
+	case "CRITICAL":
+		return PriorityUrgent
+	case "HIGH", "MEDIUM":
+		return PriorityImportant
+	case "LOW":
+		return PriorityInformational
+	default:
+		return PriorityInformational
 	}
 }

--- a/pkg/models/priority.go
+++ b/pkg/models/priority.go
@@ -17,13 +17,13 @@ const (
 var priorityToInt = map[string]int{
 	PriorityUnknown:       0,
 	PriorityInformational: 1,
-	PriorityImportant:     4,
-	PriorityUrgent:        5,
+	PriorityImportant:     3,
+	PriorityUrgent:        4,
 
 	// To be deprecated
 	PriorityNegligible: 1,
-	PriorityLow:        2,
-	PriorityMedium:     3,
+	PriorityLow:        1,
+	PriorityMedium:     2,
 }
 
 func ComparePriority(priority1, priority2 string) int {

--- a/pkg/models/priority_test.go
+++ b/pkg/models/priority_test.go
@@ -24,6 +24,32 @@ func TestComparePriority(t *testing.T) {
 		{"NONE", "UNKNOWN", 0},
 		{"UNKNOWN", "", 0},
 		{"", "UNKNOWN", 0},
+
+		// To be deprecated, for backwards compatibility
+		{"NEGIGIBLE", "URGENT", -1},
+		{"NEGIGIBLE", "IMPORTANT", -1},
+		{"NEGIGIBLE", "INFORMATIONAL", 0},
+		{"NEGIGIBLE", "UNKNOWN", 1},
+		{"NEGIGIBLE", "NONE", 1},
+		{"NEGIGIBLE", "", 1},
+		{"", "NEGIGIBLE", -1},
+		{"NEGIGIBLE", "NEGIGIBLE", 0},
+		{"LOW", "URGENT", -1},
+		{"LOW", "IMPORTANT", -1},
+		{"LOW", "INFORMATIONAL", 0},
+		{"LOW", "UNKNOWN", 1},
+		{"LOW", "NONE", 1},
+		{"LOW", "", 1},
+		{"", "LOW", -1},
+		{"LOW", "LOW", 0},
+		{"MEDIUM", "URGENT", -1},
+		{"MEDIUM", "IMPORTANT", -1},
+		{"MEDIUM", "INFORMATIONAL", 1},
+		{"MEDIUM", "UNKNOWN", 1},
+		{"MEDIUM", "NONE", 1},
+		{"MEDIUM", "", 1},
+		{"", "MEDIUM", -1},
+		{"MEDIUM", "MEDIUM", 0},
 	}
 
 	for _, test := range tests {

--- a/pkg/models/priority_test.go
+++ b/pkg/models/priority_test.go
@@ -34,3 +34,26 @@ func TestComparePriority(t *testing.T) {
 		}
 	}
 }
+
+func TestSeverityToPriority(t *testing.T) {
+	tests := []struct {
+		name     string
+		severity string
+		want     string
+	}{
+		{"Critical to Urgent", SeverityCritical, PriorityUrgent},
+		{"High to Important", SeverityHigh, PriorityImportant},
+		{"Medium to Important", SeverityMedium, PriorityImportant},
+		{"Low to Informational", SeverityLow, PriorityInformational},
+		{"Unknown to Informational", SeverityUnknown, PriorityInformational},
+		{"Empty to Informational", "", PriorityInformational},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SeverityToPriority(tt.severity); got != tt.want {
+				t.Errorf("SeverityToPriority() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

* short term backwards compatibility to prevent forced updates to hyperdrive in services that may not be ready to yet, if their config file parser versions have the breaking changes (removing the old priority levels)

## Test Plan

Please include steps to test the change. Include screenshots if applicable.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have checked for redundant or commented out code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added any appropriate tests
