### PR TITLE
chore: standardize renovate.json config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,22 +1,49 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base"
-  ],
+  "extends": ["config:recommended"],
   "timezone": "Australia/Sydney",
-  "schedule": ["* 8 1 * *"],
-  "docker": {
-    "pinDigests": true
-  },
-  "labels": ["patch"],
+  "schedule": ["* * 1 * *"],
+  "rebaseWhen": "conflicted",
+  "docker": { "pinDigests": true },
   "postUpdateOptions": ["gomodTidy", "gomodUpdateImportPaths"],
+  "labels": ["patch"],
   "separateMajorMinor": false,
   "packageRules": [
     {
-      "groupName": "Package Updates",
-      "groupSlug": "package-updates",
-      "matchUpdateTypes": ["major", "minor", "patch"],
+      "description": "Group non-major dependencies together",
+      "groupName": "Dependencies",
+      "groupSlug": "dependencies",
+      "matchUpdateTypes": ["minor", "patch", "digest", "pin", "pinDigest", "lockFileMaintenance"],
       "matchPackagePatterns": ["*"]
+    },
+    {
+      "description": "Disable major Go dependency updates (require code changes)",
+      "matchManagers": ["gomod"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
+      "description": "Disable major docker updates (may require testing)",
+      "matchManagers": ["docker-compose", "dockerfile"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
+      "description": "Allow major GitHub Actions updates (usually safe)",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["major"],
+      "groupName": "GitHub Actions Major",
+      "groupSlug": "github-actions-major"
+    },
+    {
+      "description": "Disable all Python version updates (.python-version and pyproject.toml)",
+      "matchPackageNames": ["python"],
+      "enabled": false
+    },
+    {
+      "description": "Disable pyenv manager (.python-version file updates)",
+      "matchManagers": ["pyenv"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Standardize renovate.json to use `config:recommended` instead of `config:base`
- Add standard packageRules: disable major gomod/docker updates, allow major GitHub Actions, disable Python version/pyenv updates, group non-major deps
- Add `rebaseWhen: conflicted` and consistent schedule `* * 1 * *`
- Preserved repo-specific `separateMajorMinor: false`

## Test plan
- [ ] Verify Renovate picks up the new config on next scheduled run

🤖 Generated with [Claude Code](https://claude.com/claude-code)